### PR TITLE
Commit and upload only on bundesAPI-repos (Deutschland Workflow)

### DIFF
--- a/.github/workflows/deutschland_generator.yml
+++ b/.github/workflows/deutschland_generator.yml
@@ -25,8 +25,8 @@ jobs:
         uses: wirthual/deutschland-generator-action@latest
         with:
           openapi-file: ${{ github.workspace }}/openapi.yaml
-          commit-to-git: true
-          upload-to-pypi: true
+          commit-to-git: ${{ github.repository_owner == 'bundesAPI'}}
+          upload-to-pypi: ${{ github.repository_owner == 'bundesAPI'}}
           upload-to-testpypi: false
           pypi-token: ${{ secrets.PYPI_PRODUCTION }}
           testpypi-token: ${{ secrets.PYPI_TEST }}


### PR DESCRIPTION
As used in https://github.com/bundesAPI/pegel-online-api/pull/6 only commit and upload Python-Client code if the repo is from bundesAPI. 

This should help especially while working on forks to keep the code cleaner without too many generations and commits of client code. 
