### PR TITLE
Worflows only on openapi changes

### DIFF
--- a/.github/workflows/openapi_check.yaml
+++ b/.github/workflows/openapi_check.yaml
@@ -1,12 +1,10 @@
 on:
   push:
     paths:
-      - "openapi.yaml"
-      - "openapi_en.yaml"
+      - "openapi*.yaml"
   pull_request:
     paths:
-      - "openapi.yaml"
-      - "openapi_en.yaml"
+      - "openapi*.yaml"
 
 jobs:
   openapi_check:

--- a/.github/workflows/openapi_check.yaml
+++ b/.github/workflows/openapi_check.yaml
@@ -1,4 +1,12 @@
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "openapi.yaml"
+      - "openapi_en.yaml"
+  pull_request:
+    paths:
+      - "openapi.yaml"
+      - "openapi_en.yaml"
 jobs:
     openapi_check:
       name: "OpenAPI check"

--- a/.github/workflows/openapi_check.yaml
+++ b/.github/workflows/openapi_check.yaml
@@ -7,22 +7,23 @@ on:
     paths:
       - "openapi.yaml"
       - "openapi_en.yaml"
+
 jobs:
-    openapi_check:
-      name: "OpenAPI check"
-      runs-on: ubuntu-latest
-      steps:
-        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-        - uses: actions/checkout@v2
+  openapi_check:
+    name: "OpenAPI check"
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
 
-        # Create default .spectral.yaml file used for linting if its not existing already
-        - name: "Create spectral file if it not exists"
-          continue-on-error: true
-          run: |
-             set -C; echo "extends: spectral:oas" > .spectral.yaml
+      # Create default .spectral.yaml file used for linting if its not existing already
+      - name: "Create spectral file if it not exists"
+        continue-on-error: true
+        run: |
+          set -C; echo "extends: spectral:oas" > .spectral.yaml
 
-        # Run Spectral
-        - uses: stoplightio/spectral-action@latest
-          with:
-            file_glob: openapi.yaml
-            spectral_ruleset: .spectral.yaml
+      # Run Spectral
+      - uses: stoplightio/spectral-action@latest
+        with:
+          file_glob: openapi.yaml
+          spectral_ruleset: .spectral.yaml

--- a/.github/workflows/schemathesis.yaml
+++ b/.github/workflows/schemathesis.yaml
@@ -10,14 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
-    schemathesis:
-      name: "Perform schemathesis checks"
-      runs-on: ubuntu-latest
-      steps:
+  schemathesis:
+    name: "Perform schemathesis checks"
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - run: pip install schemathesis
 
@@ -27,4 +27,3 @@ jobs:
           cmd: echo "base_url=$(yq -r .servers[].url openapi.yaml)" >> $GITHUB_ENV
 
       - run: schemathesis run ./openapi.yaml --base-url "${{ env.base_url }}" --checks all
-

--- a/.github/workflows/schemathesis.yaml
+++ b/.github/workflows/schemathesis.yaml
@@ -1,4 +1,14 @@
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "openapi.yaml"
+      - "openapi_en.yaml"
+  pull_request:
+    paths:
+      - "openapi.yaml"
+      - "openapi_en.yaml"
+  workflow_dispatch:
+
 jobs:
     schemathesis:
       name: "Perform schemathesis checks"

--- a/.github/workflows/schemathesis.yaml
+++ b/.github/workflows/schemathesis.yaml
@@ -1,12 +1,10 @@
 on:
   push:
     paths:
-      - "openapi.yaml"
-      - "openapi_en.yaml"
+      - "openapi*.yaml"
   pull_request:
     paths:
-      - "openapi.yaml"
-      - "openapi_en.yaml"
+      - "openapi*.yaml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The workflows should now only run if there are changes on `openapi.yaml` or `openapi_en.yaml`.

I also added the `workflow_dispatch` for the schemathesis workflow. With this it is possible to manual trigger the workflow, for example to see if the API changed. 

What to you think about that @wirthual ?


PS. I did not find a shorter way without adding the `paths` to pull and pull_request both. 