### PR TITLE
Fixed some openapi warnings

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,32 +3,42 @@ info:
   description: "API Description"
   version: "1.0.0"
   title: "Amtsname: API Name"
+  contact:
+    name: Zuständige Behörde
+    email: behoerde@example.de
+    url: https://example.de
 
 servers:
   - url: "https://warnung.bund.de/api31"
+
+tags:
+  - name: default
 
 paths:
   /dashboard/{AGS}.json:
     get:
       summary: Name des Endpoints
+      description: Hier wird die Funktion des Endpunktes beschrieben.
+      operationId: getAGS
+      tags:
+        - default
       responses:
-        '200':
-            description: OK
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Result'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Result"
       parameters:
         - in: path
           required: true
           name: AGS
           schema:
             type: string
-          description: Amtlicher Gebietsschlüssel - kann z.B. von [hier](https://www.xrepository.de/api/xrepository/urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:rs_2021-07-31/download/Regionalschl_ssel_2021-07-31.json) bezogen werden. Die Letzten 7 Stellen müssen dabei mit "0000000" ersetzt werden, weil die Daten nur auf [Kreisebene](https://de.wikipedia.org/wiki/Amtlicher_Gemeindeschl%C3%BCssel) bereitgestellt werden. 
+          description: Amtlicher Gebietsschlüssel - kann z.B. von [hier](https://www.xrepository.de/api/xrepository/urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:rs_2021-07-31/download/Regionalschl_ssel_2021-07-31.json) bezogen werden. Die Letzten 7 Stellen müssen dabei mit "0000000" ersetzt werden, weil die Daten nur auf [Kreisebene](https://de.wikipedia.org/wiki/Amtlicher_Gemeindeschl%C3%BCssel) bereitgestellt werden.
           example: "example-parameter"
 
-          
-components: 
-    schemas:
-      Result:
-        type: string
+components:
+  schemas:
+    Result:
+      type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,8 @@ openapi: "3.0.0"
 info:
   description: "API Description"
   version: "1.0.0"
-  title: "Amtsname: API Name"
+  title: "API Name"
+  x-office: "Amtsname"
   contact:
     name: Zuständige Behörde
     email: behoerde@example.de

--- a/openapi_en.yaml
+++ b/openapi_en.yaml
@@ -2,7 +2,8 @@ openapi: "3.0.0"
 info:
   description: "API Description"
   version: "1.0.0"
-  title: "Amtsname: API Name"
+  title: "API Name"
+  x-office: "Amtsname"
   contact:
     name: Responsible authority
     email: behoerde@example.com

--- a/openapi_en.yaml
+++ b/openapi_en.yaml
@@ -3,14 +3,25 @@ info:
   description: "API Description"
   version: "1.0.0"
   title: "Amtsname: API Name"
+  contact:
+    name: Responsible authority
+    email: behoerde@example.com
+    url: https://example.com
 
 servers:
   - url: "https://warnung.bund.de/api31"
+
+tags:
+  - name: default
 
 paths:
   /dashboard/{AGS}.json:
     get:
       summary: Name of endpoint
+      description: Here the function of the end point is described.
+      operationId: getAGS
+      tags:
+        - default
       responses:
         '200':
             description: OK
@@ -24,11 +35,11 @@ paths:
           name: AGS
           schema:
             type: string
-          description: Official area key - can be retrieved from [here](https://www.xrepository.de/api/xrepository/urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:rs_2021-07-31/download/Regionalschl_ssel_2021-07-31.json). The last 7 digits have to be replaced with "0000000" because data is only offered on the area level [Kreisebene](https://de.wikipedia.org/wiki/Amtlicher_Gemeindeschl%C3%BCssel). 
+          description: Official area key - can be retrieved from [here](https://www.xrepository.de/api/xrepository/urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:rs_2021-07-31/download/Regionalschl_ssel_2021-07-31.json). The last 7 digits have to be replaced with "0000000" because data is only offered on the area level [Kreisebene](https://de.wikipedia.org/wiki/Amtlicher_Gemeindeschl%C3%BCssel).
           example: "example-parameter"
 
-          
-components: 
+
+components:
     schemas:
       Result:
         type: string


### PR DESCRIPTION

> operation-tag-defined: openapi.yaml#L15 Operation tags must be defined in global tags.
info-contact: openapi.yaml#L2 Info object must have "contact" object.
operation-operationId: openapi.yaml#L12 Operation must have "operationId".
operation-description: openapi.yaml#L12 Operation "description" must be present and non-empty string.


- added tags
- added contact
- added operationId
- added description
- added x-office





